### PR TITLE
Fixed - wrong filename in index

### DIFF
--- a/01-GettingStarted/02-CreatingAModule/index.html
+++ b/01-GettingStarted/02-CreatingAModule/index.html
@@ -172,7 +172,7 @@
     </div>
     <!-- /.container -->
 <script src="./app/angular.min.js"></script>
-<script src="./app/mainApps.js"></script>
+<script src="./app/mainApp.js"></script>
 <script type="text/javascript">
     console.log("angular object",angular);
 </script>


### PR DESCRIPTION
Fixed a script src in index.html pointing to **mainApps.js**(ENOENT). It should point to **mainApp.js** actually, on line index.html:175 line.